### PR TITLE
Handle mllp end block edge cases

### DIFF
--- a/lib/mllp/packet_framer.ex
+++ b/lib/mllp/packet_framer.ex
@@ -13,8 +13,10 @@ defmodule MLLP.PacketFramer do
       |> Code.eval_quoted()
 
     # ^K - VT (Vertical Tab)
+    fs_sep = <<0x1C>>
+    carriage_return = <<0x0D>>
     mllp_start_of_block = <<0x0B>>
-    mllp_end_of_block = <<0x1C, 0x0D>>
+    mllp_end_of_block = fs_sep <> carriage_return
 
     frame_types =
       opt_frame_types
@@ -75,6 +77,66 @@ defmodule MLLP.PacketFramer do
             end
 
             def handle_packet(
+                  unquote(carriage_return),
+                  %FramingContext{current_message_type: unquote(message_type)} = state
+                ) do
+
+              message_type_value = unquote(message_type)
+              check = byte_size(state.receiver_buffer) - 1
+
+              case state.receiver_buffer do
+                <<message::binary-size(check), unquote(fs_sep)>> ->
+                  message_type_atom = get_message_type(message_type_value, message)
+
+                  {:ok, new_state} =
+                    state.dispatcher_module.dispatch(
+                      message_type_atom,
+                      message,
+                      %{
+                        state
+                        | # save leftovers to prepend to next packet
+                          receiver_buffer: "",
+                          current_message_type: nil
+                      }
+                    )
+
+                  {:ok, new_state}
+
+                _ ->
+                  {:ok,
+                   %{
+                     state
+                     | receiver_buffer: state.receiver_buffer <> unquote(carriage_return),
+                       current_message_type: message_type_value
+                   }}
+              end
+            end
+
+            def handle_packet(
+                unquote(mllp_end_of_block),
+                  %FramingContext{current_message_type: unquote(message_type)} = state
+                ) do
+
+              message_type_value = unquote(message_type) 
+              message = state.receiver_buffer
+              message_type_atom = get_message_type(message_type_value, message)
+
+              {:ok, new_state} =
+                state.dispatcher_module.dispatch(
+                  message_type_atom,
+                  message,
+                  %{
+                    state
+                    | # save leftovers to prepend to next packet
+                      receiver_buffer: "",
+                      current_message_type: nil
+                  }
+                )
+
+              {:ok, new_state}
+            end
+
+            def handle_packet(
                   packet,
                   %FramingContext{current_message_type: unquote(message_type)} = state
                 ) do
@@ -119,18 +181,17 @@ defmodule MLLP.PacketFramer do
             unexpected_packet,
             state
           ) do
-        mllp_start_of_block = <<0x0B>>
 
         to_chunk = unexpected_packet <> state.receiver_buffer
 
-        case String.split(to_chunk, mllp_start_of_block, parts: 2) do
+        case String.split(to_chunk, unquote(mllp_start_of_block), parts: 2) do
           [unframed] ->
             handle_unframed(unframed)
             {:ok, %{state | receiver_buffer: ""}}
 
           [unframed, next_buffer] ->
             handle_unframed(unframed)
-            handle_packet(mllp_start_of_block <> next_buffer, %{state | receiver_buffer: ""})
+            handle_packet(unquote(mllp_start_of_block) <> next_buffer, %{state | receiver_buffer: ""})
         end
       end
 

--- a/test/packet_framer_test.exs
+++ b/test/packet_framer_test.exs
@@ -121,6 +121,75 @@ defmodule MLLP.PacketFramerTest do
              } == new_state
     end
 
+    test "last byte recieved is the carriage return of an mllp block" do 
+      message1 = "hello"
+
+      packet1 = @mllp_start_of_block <> message1 <> <<0x1C>>
+      packet2 = <<0x0D>>
+
+      state = %FramingContext{dispatcher_module: MLLP.DispatcherMock}
+
+      expect(MLLP.DispatcherMock, :dispatch, fn :mllp_unknown, ^message1, state ->
+        {:ok, state}
+      end)
+
+      {:ok, new_state1} = DefaultPacketFramer.handle_packet(packet1, state)
+      {:ok, new_state2} = DefaultPacketFramer.handle_packet(packet2, new_state1)
+      
+
+      assert %{
+               state
+               | receiver_buffer: "",
+                 current_message_type: nil
+      } == new_state2
+
+
+      message2 = "hello" <> <<0x0D>> <> "world"
+      packet3 = @mllp_start_of_block <> message1
+      packet4 = <<0x0D>>
+      packet5 = "world" <> <<0x1C>>
+      packet6 = <<0x0D>>
+
+      expect(MLLP.DispatcherMock, :dispatch, fn :mllp_unknown, ^message2, state ->
+        {:ok, state}
+      end)
+
+      {:ok, new_state3} = DefaultPacketFramer.handle_packet(packet3, new_state2)
+      {:ok, new_state4} = DefaultPacketFramer.handle_packet(packet4, new_state3)
+      {:ok, new_state5} = DefaultPacketFramer.handle_packet(packet5, new_state4)
+      {:ok, new_state6} = DefaultPacketFramer.handle_packet(packet6, new_state5)
+
+      assert %{
+               state
+               | receiver_buffer: "",
+                 current_message_type: nil
+      } == new_state6
+
+    end
+
+    test "last two bytes recieved is the mllp end block" do 
+      message1 = "hello"
+
+      packet1 = @mllp_start_of_block <> message1
+      packet2 = @mllp_end_of_block
+
+      state = %FramingContext{dispatcher_module: MLLP.DispatcherMock}
+
+      expect(MLLP.DispatcherMock, :dispatch, fn :mllp_unknown, ^message1, state ->
+        {:ok, state}
+      end)
+
+      {:ok, new_state1} = DefaultPacketFramer.handle_packet(packet1, state)
+      {:ok, new_state2} = DefaultPacketFramer.handle_packet(packet2, new_state1)
+      
+
+      assert %{
+               state
+               | receiver_buffer: "",
+                 current_message_type: nil
+      } == new_state2
+    end
+
     test "simple HL7 message" do
       message = HL7.Examples.wikipedia_sample_hl7()
       packet = @mllp_start_of_block <> message <> @mllp_end_of_block


### PR DESCRIPTION
This commit resolves an issue where two edge cases were not handled:

1. A single byte is passed to the packet framer which is the last byte of a message (carriage return). When
not handling this we might simply tack is on to the buffer and continue accumulation resulting in a failure to
respond in a timely manor (i.e.,  the client is waiting on an ACK before it sends the next message).

2. Two bytes are passed and make up the mllp trailer. The effect of not handling this case is the same as above.